### PR TITLE
Remove special novel and game pit entries

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -62,9 +62,7 @@ const navItems = [
   { name: '事件', path: '/category/events' },
   { name: '概念', path: '/category/concepts' },
   { name: '小说坑', path: '/novels' },
-  { name: '游戏坑', path: '/games' },
-  { name: '小说Wiki', path: '/category/novels' },
-  { name: '游戏Wiki', path: '/category/games' }
+  { name: '游戏坑', path: '/games' }
 ];
 
 // 检查用户偏好和系统设置

--- a/src/views/GamesPage.vue
+++ b/src/views/GamesPage.vue
@@ -28,7 +28,6 @@
           <a href="#concept" class="btn btn-secondary">构思中的点子</a>
           <a href="#released" class="btn btn-secondary">已发布游戏</a>
           <a href="#archived" class="btn btn-secondary">已归档项目</a>
-          <router-link to="/category/games" class="btn btn-primary">查看游戏Wiki条目</router-link>
         </div>
       </div>
 

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -123,18 +123,6 @@ const categories = [
     symbolClass: 'concept-symbol'
   },
   {
-    title: '小说坑',
-    path: '/category/novels',
-    description: '探索托贝诺特的小说作品',
-    symbolClass: 'novel-symbol'
-  },
-  {
-    title: '游戏坑',
-    path: '/category/games',
-    description: '了解托贝诺特的游戏项目',
-    symbolClass: 'game-symbol'
-  },
-  {
     title: '作品',
     path: '/works',
     description: '按作品/篇章组织浏览',

--- a/src/views/NovelsPage.vue
+++ b/src/views/NovelsPage.vue
@@ -27,7 +27,6 @@
           <a href="#planned" class="btn btn-secondary">计划中的作品</a>
           <a href="#completed" class="btn btn-secondary">已完成的作品</a>
           <a href="#archived" class="btn btn-secondary">已归档的作品</a>
-          <router-link to="/category/novels" class="btn btn-primary">查看小说Wiki条目</router-link>
         </div>
       </div>
 


### PR DESCRIPTION
Remove "Novels" and "Games" as wiki categories, retaining them only as special homepage entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bf579f1-6073-43a7-9031-2b62158ea7bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9bf579f1-6073-43a7-9031-2b62158ea7bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

